### PR TITLE
TX dals should inherit before/afters from existing instance

### DIFF
--- a/lib/dirac.js
+++ b/lib/dirac.js
@@ -469,6 +469,8 @@ dirac.tx = {
     Object.keys( dirac.Dals ).forEach( function( tbl ){
       var Dal = dirac.Dals[ tbl ];
       tx[ tbl ] = new Dal( client );
+      tx[ tbl ].befores = dirac.dals[ tbl ].befores;
+      tx[ tbl ].afters  = dirac.dals[ tbl ].afters;
     });
 
     return tx;


### PR DESCRIPTION
Perhaps then before/afters should be on the prototype. Until then, we we'll just monkey-patch the references.
