### PR TITLE
Mixin relationship helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,13 @@ Dirac has the following built-in middleware modules:
 
 The relationships middleware allows you to easily embed foreign data in your result set. Dirac uses the schemas defined with `dirac.register` to build a dependency graph of your schemas with pivots on foreign key relationships. It uses this graph to build the proper sub-queries to embed one-to-one or one-to-many type structures.
 
+__Relationships Directives__
+
+* [One](#relationships-one)
+* [Many](#relationships-many)
+* [Pluck](#relationships-pluck)
+* [Mixin](#relationships-mixin)
+
 __Usage:__
 
 ```javascript
@@ -785,3 +792,65 @@ dirac.dals.orders.findOne( user.id, options, function( error, user ){
 ```
 
 This is all done with a single query to the database without any result coercion.
+
+#### Relationships: One
+
+Applies a one-to-one relationship on the query:
+
+```javascript
+// orders (id, user_id, ...)
+// users (id, ...)
+dirac.dals.orders.find( {}, {
+  one: [{ table: 'users', alias: 'user' }]
+})
+
+// [{ id: 1, user: { ... } }, { id: 2, user: { ... } }]
+```
+
+#### Relationships: Many
+
+Applies a one-to-many relationship on the query:
+
+```javascript
+// users (id, ...)
+// orders (id, user_id, ...)
+dirac.dals.users.findOne( 32, {
+  many: [{ table: 'orders', alias: 'orders' }]
+})
+
+// { id: 32, orders: [{ id: 1, user_id: 32, ... }, { id: 2, user_id: 32, ... }] }
+```
+
+#### Relationships: Pluck
+
+Like [Many](#relationships-many), but maps on a single field:
+
+```javascript
+// users (id, ...)
+// groups (id, user_id, name, ...)
+dirac.dals.users.findOne( 32, {
+  pluck: [{ table: 'groups', column: 'name' }]
+})
+
+// { id: 32, groups: ['client', 'cool-guys'] }
+```
+
+#### Relationships: Mixin
+
+Like [One](#relationships-one), but mixes in the properties from the target into the source (basically a more abstract join).
+
+```javascript
+// Useful for junction tables
+// user_invoices (id, user_id, ...)
+// user_invoice_orders (id, user_invoice_id, order_id, ...)
+// orders (id, ...)
+db.user_invoices.findOne( 1, {
+ many: [ { table: 'user_invoice_orders'
+         , alias: 'orders'
+         , mixin: [ { table: 'orders' } ]
+         }
+       ]
+})
+
+// { id: 1, orders: [{ id: 1, user_invoice_id: 1, user_id: 1 }, ... ] }
+```

--- a/lib/dal.js
+++ b/lib/dal.js
@@ -51,7 +51,7 @@ module.exports = utils.Class.extend({
     if ( this.connString ) {
       pg.connect( this.connString, function( error, client, done ){
         if (error) return callback( error );
-
+console.log(query);
         client.query( query, values, function( error, result ){
           done();
 

--- a/lib/dal.js
+++ b/lib/dal.js
@@ -51,7 +51,7 @@ module.exports = utils.Class.extend({
     if ( this.connString ) {
       pg.connect( this.connString, function( error, client, done ){
         if (error) return callback( error );
-console.log(query);
+
         client.query( query, values, function( error, result ){
           done();
 

--- a/middleware/relationships.js
+++ b/middleware/relationships.js
@@ -80,6 +80,11 @@ module.exports = function( options ){
               applyPluck( main.table, main );
             }
 
+            if ( Array.isArray( main.mixin ) ){
+              main.mixin.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyMixin( main.table, main );
+            }
+
             return {
               type: 'expression'
             , alias: data.alias
@@ -132,6 +137,91 @@ module.exports = function( options ){
           });
         };
 
+        var applyMixin = function( table_name, $query ){
+          console.log('applyMixin', table_name);
+          var cid = 1;
+          var tmpl = function( data ){
+            var where = utils.extend( {}, data.where );
+            var on = utils.extend( {}, data.on );
+
+            data.pivots.forEach( function( p ){
+              where[ p.target_col ] = on[ p.target_col ] = '$' + mosqlUtils.quoteObject( p.source_col, data.source ) + '$';
+            });
+
+            var main = utils.extend({
+              type:     'select'
+            , table:    data.target
+            , alias:    data.qAlias
+            , where:    where
+            , limit:    1
+            }, utils.omit( data, ['table', 'alias', 'pivots', 'target', 'source', 'where', 'on'] ));
+
+            if ( Array.isArray( main.one ) ){
+              main.one.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyOne( main.table, main );
+            }
+
+            if ( Array.isArray( main.many ) ){
+              main.many.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyMany( main.table, main );
+            }
+
+            if ( Array.isArray( main.pluck ) ){
+              main.pluck.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyPluck( main.table, main );
+            }
+
+            if ( Array.isArray( main.mixin ) ){
+              main.mixin.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyMixin( main.table, main );
+            }
+
+            return {
+              type:   'left'
+            , alias:  data.alias + '_' + cid++
+            , target: main
+            , on:     on
+            };
+          };
+
+          $query.mixin.forEach( function( target ){
+            var targetDal = dirac.dals[ target.table ];
+
+            // Immediate dependency not met and not specifying how to get there
+            if ( !targetDal && !target.where ){
+              throw new Error( 'Must specify how to relate table `' + table_name + '` to target `' + target.table + '`' );
+            }
+
+            var pivots = [];
+
+            if ( targetDal )
+            if ( targetDal.dependents[ table_name ] ){
+               pivots = Object.keys( targetDal.dependents[ table_name ] ).map( function( p ){
+                return {
+                  source_col: targetDal.dependents[ table_name ][ p ]
+                , target_col: p
+                };
+              });
+            }
+
+            var context = utils.extend({
+              source:     target.source || table_name
+            , target:     target.table
+            , alias:      target.alias || target.table
+            , pivots:     pivots
+            , qAlias:     'r'
+            }, target );
+
+            context.alias = context.alias || target.table;
+
+            if ( !$query.joins ){
+              $query.joins = [];
+            }
+
+            $query.joins.push( tmpl( context ) );
+          });
+        };
+
         var applyMany = function( table_name, $query ){
           var tmpl = function( data ){
             var where = utils.extend( {}, data.where );
@@ -160,6 +250,11 @@ module.exports = function( options ){
             if ( Array.isArray( main.pluck ) ){
               main.pluck.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
               applyPluck( main.table, main );
+            }
+
+            if ( Array.isArray( main.mixin ) ){
+              main.mixin.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyMixin( main.table, main );
             }
 
             return {
@@ -250,6 +345,11 @@ module.exports = function( options ){
               applyPluck( main.table, main );
             }
 
+            if ( Array.isArray( main.mixin ) ){
+              main.mixin.forEach( function( t ){ t.qAlias = t.qAlias || (data.qAlias + 'r'); });
+              applyMixin( main.table, main );
+            }
+
             return {
               type: 'expression'
             , alias: data.alias
@@ -317,6 +417,7 @@ module.exports = function( options ){
               if ( Array.isArray( $query.many ) )   applyMany( table_name, $query );
               if ( Array.isArray( $query.one ) )    applyOne( table_name, $query );
               if ( Array.isArray( $query.pluck ) )  applyPluck( table_name, $query );
+              if ( Array.isArray( $query.mixin ) )  applyMixin( table_name, $query );
               return next();
             });
           });

--- a/middleware/relationships.js
+++ b/middleware/relationships.js
@@ -138,14 +138,13 @@ module.exports = function( options ){
         };
 
         var applyMixin = function( table_name, $query ){
-          console.log('applyMixin', table_name);
           var cid = 1;
           var tmpl = function( data ){
             var where = utils.extend( {}, data.where );
             var on = utils.extend( {}, data.on );
 
             data.pivots.forEach( function( p ){
-              where[ p.target_col ] = on[ p.target_col ] = '$' + mosqlUtils.quoteObject( p.source_col, data.source ) + '$';
+              /*where[ p.target_col ] = */on[ p.target_col ] = '$' + mosqlUtils.quoteObject( p.source_col, data.source ) + '$';
             });
 
             var main = utils.extend({
@@ -178,8 +177,8 @@ module.exports = function( options ){
 
             return {
               type:   'left'
-            , alias:  data.alias + '_' + cid++
-            , target: main
+            , alias:  data.qalias
+            , target: data.target
             , on:     on
             };
           };
@@ -217,6 +216,12 @@ module.exports = function( options ){
             if ( !$query.joins ){
               $query.joins = [];
             }
+
+            if ( !$query.columns ){
+              $query.columns = ['*'];
+            }
+
+            $query.columns.push({ table: context.alias, name: '*' })
 
             $query.joins.push( tmpl( context ) );
           });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,3 +1,4 @@
+var _         = require('lodash');
 var async     = require('async');
 var dirac     = require('../');
 var assert    = require('assert');
@@ -351,6 +352,119 @@ describe ('Middleware', function(){
             });
 
             next();
+          });
+        }
+      ], done );
+    });
+
+    it.only( 'Should describe a mixin relationship', function( done ){
+      dirac.use( dirac.relationships() );
+
+      dirac.register({
+        name: 'users'
+      , schema: {
+          id:    { type: 'serial', primaryKey: true }
+        , email: { type: 'text' }
+        }
+      });
+
+      dirac.register({
+        name: 'orders'
+      , schema: {
+          id:    { type: 'serial', primaryKey: true }
+        , uid:   { type: 'integer', references: { table: 'users', column: 'id' } }
+        }
+      });
+
+      dirac.register({
+        name: 'invoices'
+      , schema: {
+          id:    { type: 'serial', primaryKey: true }
+        , uid:   { type: 'int', references: { table: 'users', column: 'id' } }
+        }
+      });
+
+      dirac.register({
+        name: 'invoice_orders'
+      , schema: {
+          id:    { type: 'serial', primaryKey: true }
+        , iid:   { type: 'integer', references: { table: 'invoices', column: 'id' } }
+        , oid:   { type: 'integer', references: { table: 'orders', column: 'id' } }
+        }
+      });
+
+      dirac.init({ connString: 'postgres://localhost/dirac_test' });
+
+      async.waterfall([
+        dirac.sync.bind( dirac, { force: true } )
+        // Insert some noise in our data
+      , dirac.dals.users.insert.bind( dirac.dals.users, { email: 'test1@test.com '} )
+      , function( user, next ){
+          return dirac.dals.orders.insert( { uid: user.id }, next );
+        }
+      , function( order, next ){
+          dirac.dals.users.insert( { email: 'poop@poop.com' }, function( error, user ){
+            assert( !error, error );
+
+            user = user[0];
+
+            assert( user.id );
+
+            next( null, user );
+          });
+        }
+
+      , function( user, next ){
+          var orders = new Array(2)
+            .join()
+            .split(',')
+            .map( _.identity.bind( null, { uid: user.id }) );
+
+          dirac.dals.orders.insert( orders, function( error, results ){
+            return next( error, user, results );
+          });
+        }
+
+      , function( user, orders, next ){
+          var doc = {
+            uid: user.id
+          };
+
+          dirac.dals.invoices.insert( doc, function( error, invoice ){
+            return next( error, user, orders, invoice[0] );
+          });
+        }
+
+      , function( user, orders, invoice, next ){
+          var uios = orders.map( function( order ){
+            return { oid: order.id, iid: invoice.id };
+          });
+
+          dirac.dals.invoice_orders.insert( uios, function( error, results ){
+            return next( error, user, orders, invoice, results );
+          });
+        }
+
+      , function( user, orders, invoice, uios, next ){
+          dirac.dals.invoices.findOne( invoice.id, {
+            many: [ { table: 'invoice_orders'
+                    , alias: 'orders' 
+                    , mixin: [{ table: 'orders'}]
+                    }
+                  ]
+          }, function( error, result ){
+            if ( error ) return next( error );
+
+            assert.equal( result.id, invoice.id );
+            assert.equal( result.orders.length, uios.length );
+
+            uios.forEach( function( uio, i ){
+              assert.equal( result.orders[ i ].iid, uio.iid );
+              assert.equal( result.orders[ i ].oid, uio.oid );
+              assert.equal( result.orders[ i ].uid, user.id );
+            });
+
+            return next();
           });
         }
       ], done );

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -357,7 +357,7 @@ describe ('Middleware', function(){
       ], done );
     });
 
-    it.only( 'Should describe a mixin relationship', function( done ){
+    it( 'Should describe a mixin relationship', function( done ){
       dirac.use( dirac.relationships() );
 
       dirac.register({


### PR DESCRIPTION
With dirac, you can pretty elegantly handle one-to-one, one-to-many, and many-to-many relationships

```
user_invoices (id, user_id, ...)
user_invoice_orders (id, user_invoice_id, order_id, ...)
orders (id, ...)
````

consider that sort of junction table for many-to-many

```javascript
db.user_invoices.find( {}, {
 many: [ { table: 'user_invoice_orders', alias: 'orders'
         , one: [ { table: 'orders', alias: 'order'} ]
         }
       ]
})
```

You could do that and each junction record will now contain a full order object
So, `many` on the junction table, and `one` on orders
But that's kinda weird because it's a little redundant - we really just want to do a standard left join on those

I could just add that join manually actually, but that wouldn't take advantage of relationships middleware cached dependency graph

So, I guess I'll add a new relationships type - mixin

```javascript
db.user_invoices.find( {}, {
 many: [ { table: 'user_invoice_orders'
         , alias: 'orders'
         , mixin: [ { table: 'orders' } ]
         }
       ]
})
```