### PR TITLE
Allow one/mixin middlewares to traverse dep. graph both ways

### DIFF
--- a/middleware/relationships.js
+++ b/middleware/relationships.js
@@ -119,6 +119,16 @@ module.exports = function( options ){
               });
             }
 
+            if ( targetDal )
+            if ( targetDal.dependencies[ table_name ] ){
+               pivots = pivots.concat( Object.keys( targetDal.dependencies[ table_name ] ).map( function( p ){
+                return {
+                  source_col: targetDal.dependencies[ table_name ][ p ]
+                , target_col: p
+                };
+              }));
+            }
+
             var context = utils.extend({
               source:     target.source || table_name
             , target:     target.table
@@ -201,6 +211,16 @@ module.exports = function( options ){
                 , target_col: p
                 };
               });
+            }
+
+            if ( targetDal )
+            if ( targetDal.dependencies[ table_name ] ){
+               pivots = pivots.concat( Object.keys( targetDal.dependencies[ table_name ] ).map( function( p ){
+                return {
+                  source_col: targetDal.dependencies[ table_name ][ p ]
+                , target_col: p
+                };
+              }));
             }
 
             var context = utils.extend({


### PR DESCRIPTION
This is useful when you have a one->many relationship that can be drilled down to a one->one:

```javascript
dirac.dals.users.findOne( 10, {
  one: [ { table: 'addresses'
         , alias: 'address'
         , where: { is_default: true }
         }
       ]
);
```
